### PR TITLE
Add loader.js as the main entry-point for node

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"type": "git",
 		"url": "https://github.com/dojo/loader.git"
 	},
+	"main": "loader.js",
 	"devDependencies": {
 		"dts-generator": "1.4.1",
 		"grunt": "0.4.5",


### PR DESCRIPTION
This pull request allows the loader to be imported using `require('dojo-loader')` rather than `require('dojo-loader/loader')`.