### PR TITLE
Add branch to load modules (for plugins) in a none node environment

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -373,7 +373,7 @@ export interface RootRequire extends Require {
 		if (typeof a1 === 'string') {
 			module = getModule(a1, referenceModule);
 			if (module.executed !== true && module.executed !== EXECUTING) {
-				if (has('host-node')) {
+				if (has('host-node') && !module.plugin) {
 					let result = nodeLoadModule(module.mid, referenceModule);
 					if (result) {
 						initModule(module, [], null);

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -385,6 +385,9 @@ export interface RootRequire extends Require {
 						throw new Error('Attempt to require unloaded module ' + module.mid);
 					}
 				}
+				else {
+                    injectModule(module, null);
+                }
 			}
 			// Assign the result of the module to `module`
 			// otherwise require('moduleId') returns the internal


### PR DESCRIPTION
Not sure if this is right. I would like to discuss. I ran into an issue resulting in the need for this addition while implementing dojo-core/has as a plugin. Essentially, without this code addition it was not loading the feature. 

I recognize that it is quite possible things need to change on the dojo-core/has side instead of this change. But I figured this would highlight the issue and be a good starting point for that discussion.