### PR TITLE
Pass loader config when loading a plugin

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -154,6 +154,9 @@ interface ModuleDefinitionArguments extends Array<any> {
 
 	let checkCompleteGuard: number = 0;
 
+	// The configuration passed to the loader
+	let config = {};
+
 	// The arguments sent to loader via AMD define().
 	let moduleDefinitionArguments: ModuleDefinitionArguments = null;
 
@@ -275,6 +278,7 @@ interface ModuleDefinitionArguments extends Array<any> {
 		 */
 		var configure: (configuration: Config) => void = requireModule.config = function (configuration: Config): void {
 			// TODO: Expose all properties on req as getter/setters? Plugin modules like dojo/node being able to
+			config = configuration;
 			// retrieve baseUrl is important. baseUrl is defined as a getter currently.
 			baseUrl = (configuration.baseUrl || baseUrl).replace(/\/*$/, '/');
 
@@ -748,7 +752,7 @@ interface ModuleDefinitionArguments extends Array<any> {
 			};
 
 		if (plugin.load) {
-			plugin.load(module.prid, module.req, onLoad);
+			plugin.load(module.prid, module.req, onLoad, config);
 		}
 		else if (plugin.loadQ) {
 			plugin.loadQ.push(module);


### PR DESCRIPTION
This seems to be the right config to pass to the loader, but if it is, the relevant section of the [AMD Spec](https://github.com/amdjs/amdjs-api/blob/master/LoaderPlugins.md#load-function-resourceid-require-load-config-) seems to indicate that an `isBuild` property can be passed to a plugin via `config`. If that should be passed to the plugin via the configuration provided to the loader I presume we'll need to add that property to the [`Config` interface](https://github.com/dojo/loader/blob/051fbb30b53c744ef45ae2fcb90ba78a276c5cd1/src/loader.ts#L6-L11)
Fixes #34