### PR TITLE
Mapped plugins were losing relative paths

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -522,7 +522,7 @@ const globalObject: any = Function('return this')();
 		// plugin!arg ?-> mappedPlugin + ! + arg
 
 		// Do inital check on the passed in moduleId
-		let passedModuleMatch = moduleId.match(pluginRegEx);
+		const passedModuleMatch = moduleId.match(pluginRegEx);
 		if (passedModuleMatch) {
 			// Passed in moduleId is a plugin, so check the map using only the plugin name
 			// then reconstruct using the pluginArgs
@@ -535,7 +535,7 @@ const globalObject: any = Function('return this')();
 		}
 
 		// Do final check on the mapped module / plugin Id to see what we're dealing with
-		let mappedModuleMatch = moduleId.match(pluginRegEx);
+		const mappedModuleMatch = moduleId.match(pluginRegEx);
 		if (mappedModuleMatch) {
 			module = getPluginInformation(moduleId, mappedModuleMatch, referenceModule);
 		}

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -514,19 +514,33 @@ const globalObject: any = Function('return this')();
 		let module: DojoLoader.Module;
 		const pluginRegEx = /^(.+?)\!(.*)$/;
 
-		// Update moduleId from map if exists
-		moduleId = updateModuleIdFromMap(moduleId, referenceModule);
+		// Foreseable situations (where ?-> is a map lookup function)
+		// module
+		// plugin!arg
+		// module ?-> mappedModule
+		// module ?-> mappedPlugin!arg
+		// plugin!arg ?-> mappedPlugin + ! + arg
 
-		// check if module is a plugin-module
-		const match = moduleId.match(pluginRegEx);
-
-		if (match) {
-			// name was <plugin-module>!<plugin-resource-id>
-			module = getPluginInformation(moduleId, match, referenceModule);
+		// Do inital check on the passed in moduleId
+		let passedModuleMatch = moduleId.match(pluginRegEx);
+		if (passedModuleMatch) {
+			// Passed in moduleId is a plugin, so check the map using only the plugin name
+			// then reconstruct using the pluginArgs
+			let pluginId: string = updateModuleIdFromMap(passedModuleMatch[1], referenceModule);
+			moduleId = `${pluginId}!${passedModuleMatch[2]}`;
+		} else {
+			// Not a module, so check the map using the full moduleId passed
+			moduleId = updateModuleIdFromMap(moduleId, referenceModule);
 		}
-		else {
+
+		// Do final check on the mapped module / plugin Id to see what we're dealing with
+		let mappedModuleMatch = moduleId.match(pluginRegEx);
+		if (mappedModuleMatch ) {
+			module = getPluginInformation(moduleId, mappedModuleMatch, referenceModule);
+		} else {
 			module = getModuleInformation(moduleId, referenceModule);
 		}
+
 		return modules[module.mid] || (modules[module.mid] = module);
 	}
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -528,16 +528,18 @@ const globalObject: any = Function('return this')();
 			// then reconstruct using the pluginArgs
 			let pluginId: string = updateModuleIdFromMap(passedModuleMatch[1], referenceModule);
 			moduleId = `${pluginId}!${passedModuleMatch[2]}`;
-		} else {
+		}
+		else {
 			// Not a module, so check the map using the full moduleId passed
 			moduleId = updateModuleIdFromMap(moduleId, referenceModule);
 		}
 
 		// Do final check on the mapped module / plugin Id to see what we're dealing with
 		let mappedModuleMatch = moduleId.match(pluginRegEx);
-		if (mappedModuleMatch ) {
+		if (mappedModuleMatch) {
 			module = getPluginInformation(moduleId, mappedModuleMatch, referenceModule);
-		} else {
+		}
+		else {
 			module = getModuleInformation(moduleId, referenceModule);
 		}
 

--- a/tests/unit/require.ts
+++ b/tests/unit/require.ts
@@ -634,7 +634,7 @@ registerSuite({
 
 	plugin: {
 		load() {
-			let dfd = this.async(DEFAULT_TIMEOUT);
+			const dfd = this.async(DEFAULT_TIMEOUT);
 
 			global.require.config({
 				paths: {
@@ -650,8 +650,8 @@ registerSuite({
 		},
 
 		config() {
-			let dfd = this.async(DEFAULT_TIMEOUT);
-			let paths = {
+			const dfd = this.async(DEFAULT_TIMEOUT);
+			const paths = {
 				common: '_build/tests/common'
 			};
 
@@ -667,11 +667,11 @@ registerSuite({
 		},
 
 		mergedConfig() {
-			let dfd = this.async(DEFAULT_TIMEOUT);
-			let paths = {
+			const dfd = this.async(DEFAULT_TIMEOUT);
+			const paths = {
 				common: '_build/tests/common'
 			};
-			let map = {
+			const map = {
 				foo: 'bar'
 			};
 
@@ -687,12 +687,13 @@ registerSuite({
 		},
 
 		relativePluginPaths() {
-			let dfd = this.async(DEFAULT_TIMEOUT);
-			let paths = {
-				common: '_build/tests/common'
-			};
+			const dfd = this.async(DEFAULT_TIMEOUT);
 
-			global.require.config({ paths });
+			global.require.config({
+				paths: {
+					common: '_build/tests/common'
+				}
+			});
 
 			global.require([
 				'common/plugin!../../location'

--- a/tests/unit/require.ts
+++ b/tests/unit/require.ts
@@ -684,6 +684,21 @@ registerSuite({
 				assert.deepEqual(pluginConfig.paths, paths, 'Paths should be equal');
 				assert.deepEqual(pluginConfig.map, map, 'Map should be equal');
 			}));
+		},
+
+		relativePluginPaths() {
+			let dfd = this.async(DEFAULT_TIMEOUT);
+			let paths = {
+				common: '_build/tests/common'
+			};
+
+			global.require.config({ paths });
+
+			global.require([
+				'common/plugin!../../location'
+			], dfd.callback(function (pluginLocation: any) {
+				assert.strictEqual(pluginLocation, '../../location', 'Plugin should location it was passed');
+			}));
 		}
 	}
 });

--- a/tests/unit/require.ts
+++ b/tests/unit/require.ts
@@ -697,7 +697,7 @@ registerSuite({
 			global.require([
 				'common/plugin!../../location'
 			], dfd.callback(function (pluginLocation: any) {
-				assert.strictEqual(pluginLocation, '../../location', 'Plugin should location it was passed');
+				assert.strictEqual(pluginLocation, '../../location', 'Plugin should return location it was passed correctly');
 			}));
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/dojo/loader/issues/54
Loader now caters for and tests the following scenarios (where ?-> is the mapped module lookup function:

- module
- plugin!arg
- module ?-> mappedModule
- module ?-> mappedPlugin!arg
- plugin!arg ?-> mappedPlugin + ! + arg