### PR TITLE
meta #25: Compile ES6 version of loader

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -322,6 +322,10 @@ module.exports = function (grunt) {
 
 	grunt.registerTask('test-es6', function () {
 		tsOptions.target = 'es6';
+		grunt.config('intern.options.nodeOptions', [
+			'--harmony',
+			'--harmony_default_parameters'
+		]);
 		grunt.task.run('test');
 	});
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"intern": "3.0.6",
 		"istanbul": "0.4.2",
 		"remap-istanbul": "0.5.1",
-		"tslint": "3.5.0",
-		"typescript": "1.8.2"
+		"tslint": "3.6.0",
+		"typescript": "1.8.9"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,
-		"target": "es5",
+		"target": "es6",
 		"moduleResolution": "classic"
 	},
 	"filesGlob": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,
-		"target": "es6",
+		"target": "es5",
 		"moduleResolution": "classic"
 	},
 	"filesGlob": [


### PR DESCRIPTION
Addresses: https://github.com/dojo/meta/issues/25
Requires Intern release and `nodeOptions` pr merge: https://github.com/theintern/intern/pull/604#