### PR TITLE
meta #25: Compile ES6 version of loader

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -328,17 +328,23 @@ module.exports = function (grunt) {
 		'replace:addIstanbulIgnore',
 		'updateTsconfig'
 	]);
-	grunt.registerTask('dist', [
-		'tslint',
-		'ts:dist',
-		'rename:sourceMaps',
-		'rewriteSourceMaps',
-		'copy:typings',
-		'copy:staticFiles',
-		'dtsGenerator:dist',
-		'updatePackageJson',
-		'uglify:dist'
-	]);
+
+	grunt.registerTask('dist', function () {
+		var tasks = [
+			'tslint',
+			'ts:dist',
+			'rename:sourceMaps',
+			'rewriteSourceMaps',
+			'copy:typings',
+			'copy:staticFiles',
+			'dtsGenerator:dist',
+			'updatePackageJson'
+		];
+		if (tsOptions.target !== 'es6') {
+			tasks.push('uglify:dist');
+		}
+		grunt.task.run(tasks);
+	});
 
 	grunt.registerTask('config-es6', function () {
 		tsOptions.target = 'es6';

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -322,6 +322,10 @@ module.exports = function (grunt) {
 
 	grunt.registerTask('test-es6', function () {
 		tsOptions.target = 'es6';
+		grunt.config('intern.options.nodeOptions', [
+			'--harmony',
+			'--harmony_default_parameters'
+		]);
 		grunt.task.run('test');
 	});
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -320,20 +320,6 @@ module.exports = function (grunt) {
 		grunt.task.run('clean:coverage');
 	});
 
-	grunt.registerTask('test-es6', function () {
-		tsOptions.target = 'es6';
-		grunt.config('intern.options.nodeOptions', [
-			'--harmony',
-			'--harmony_default_parameters'
-		]);
-		grunt.task.run('test');
-	});
-
-	grunt.registerTask('dev-es6', function () {
-		tsOptions.target = 'es6';
-		grunt.task.run('dev');
-	});
-
 	grunt.registerTask('dev', [
 		'tslint',
 		'ts:dev',
@@ -353,6 +339,22 @@ module.exports = function (grunt) {
 		'updatePackageJson',
 		'uglify:dist'
 	]);
+
+	grunt.registerTask('config-es6', function () {
+		tsOptions.target = 'es6';
+		if (this.flags.test) {
+			grunt.config('intern.options.nodeOptions', [
+				'--harmony',
+				'--harmony_default_parameters',
+				'--harmony_destructuring'
+			]);
+		}
+	});
+
+	grunt.registerTask('test-es6', [ 'config-es6:test', 'test' ]);
+	grunt.registerTask('dev-es6', [ 'config-es6', 'dev' ]);
+	grunt.registerTask('dist-es6', [ 'config-es6', 'dist' ]);
+
 	grunt.registerTask('test-proxy', [ 'dev', 'intern:proxy' ]);
 	grunt.registerTask('default', [ 'clean', 'dev' ]);
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"intern": "3.0.6",
 		"istanbul": "0.4.2",
 		"remap-istanbul": "0.5.1",
-		"tslint": "3.5.0",
-		"typescript": "1.8.2"
+		"tslint": "3.6.0",
+		"typescript": "1.8.9"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,
-		"target": "es5",
+		"target": "es6",
 		"moduleResolution": "classic"
 	},
 	"filesGlob": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,
-		"target": "es6",
+		"target": "es5",
 		"moduleResolution": "classic"
 	},
 	"filesGlob": [


### PR DESCRIPTION
### Issue
Addresses: https://github.com/dojo/meta/issues/25
### Pre-reqs
Requires Intern release and `nodeOptions` pr merge: https://github.com/theintern/intern/pull/604#
### new grunt tasks
- `grunt dev-es6` - runs `dev` task with `tsOptions.target` set to `es6`
- `grunt test-es6` - runs `test` task with `tsOptions.target` set to `es6` and node `harmony` flags enabled
- `grunt dist-es6` - runs `dev` task with `tsOptions.target` set to `es6` but does not run `uglify`