### PR TITLE
#57: vm.runInThisContext added options arg

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -897,7 +897,10 @@
 					let oldModule = globalObject.module;
 					globalObject.module = undefined;
 					try {
-						vm.runInThisContext(data, url);
+						vm.runInThisContext(data, {
+							filename: url,
+							displayErrors: true
+						});
 					}
 					finally {
 						globalObject.module = oldModule;


### PR DESCRIPTION
Covers: https://github.com/dojo/loader/issues/57
Doesn't fix the underlying problem but ensures that it does not lay with the loader.

node docs: https://nodejs.org/api/vm.html#vm_vm_runinthiscontext_code_options