### PR TITLE
Update to allow testing against Sauce Labs and Browserstack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ install:
 script:
   - "grunt"
   - "grunt intern:node --combined"
-  - "grunt intern:remote --combined"
+  - "grunt intern:saucelabs --combined"
   - "grunt remapIstanbul:ci"
   - "grunt uploadCoverage"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -121,6 +121,12 @@ module.exports = function (grunt) {
 				config: '<%= devDirectory %>/tests/intern',
 				reporters: [ 'Runner' ]
 			},
+			browserstack: {},
+			saucelabs: {
+				options: {
+					config: '<%= devDirectory %>/tests/intern-saucelabs'
+				}
+			},
 			remote: {},
 			local: {
 				options: {

--- a/tests/intern-saucelabs.ts
+++ b/tests/intern-saucelabs.ts
@@ -1,0 +1,22 @@
+export * from './intern';
+
+export var capabilities = {
+	project: 'Dojo 2',
+	name: 'dojo-loader',
+	fixSessionCapabilities: false
+};
+
+export var environments = [
+	{ browserName: 'internet explorer', version: [ '9.0', '10.0', '11.0' ], platform: 'Windows 7' }/*,
+	{ browserName: 'microsoftedge', platform: 'Windows 10' }*/,
+	{ browserName: 'firefox', platform: 'Windows 10' },
+	{ browserName: 'chrome', platform: 'Windows 10' },
+	{ browserName: 'safari', version: '9', platform: 'OS X 10.11' },
+	{ browserName: 'android', platform: 'Linux', version: '4.4', deviceName: 'Google Nexus 7 HD Emulator' }/*,
+	{ browserName: 'safari', version: '7', platform: 'OS X 10.9' }*/
+];
+
+/* SauceLabs supports more max concurrency */
+export const maxConcurrency = 4;
+
+export const tunnel = 'SauceLabsTunnel';

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -9,30 +9,28 @@ export var proxyUrl = 'http://localhost:9000/';
 // https://saucelabs.com/docs/additional-config#desired-capabilities for Sauce Labs capabilities.
 // Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
 // automatically
-export var capabilities = {
+export const capabilities = {
+	'browserstack.debug': false,
 	project: 'Dojo 2',
-	name: 'dojo-loader',
-	fixSessionCapabilities: false
+	name: 'dojo-loader'
 };
 
 // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
 // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
 // capabilities options specified for an environment will be copied as-is
-export var environments = [
-	{ browserName: 'internet explorer', version: [ '9.0', '10.0', '11.0' ], platform: 'Windows 7' }/*,
-	{ browserName: 'microsoftedge', platform: 'Windows 10' }*/,
-	{ browserName: 'firefox', platform: 'Windows 10' },
-	{ browserName: 'chrome', platform: 'Windows 10' },
-	{ browserName: 'safari', version: '9', platform: 'OS X 10.11' },
-	{ browserName: 'android', platform: 'Linux', version: '4.4', deviceName: 'Google Nexus 7 HD Emulator' }/*,
-	{ browserName: 'safari', version: '7', platform: 'OS X 10.9' }*/
+export const environments = [
+	{ browserName: 'internet explorer', version: [ '9', '10', '11' ], platform: 'WINDOWS' },
+	{ browserName: 'firefox', platform: 'WINDOWS' },
+	{ browserName: 'chrome', platform: 'WINDOWS' },
+	/*{ browserName: 'Safari', version: '9', platform: 'OS X' }*/
+	{ browserName: 'android', version: ['4.4'], platform: 'ANDROID'}
 ];
 
 // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
 export var maxConcurrency = 3;
 
 // Name of the tunnel class to use for WebDriver tests
-export var tunnel = 'SauceLabsTunnel';
+export var tunnel = 'BrowserStackTunnel';
 
 // Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader
 // can be used here

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
 		"./tests/functional/executeTest.ts",
 		"./tests/functional/require/require.ts",
 		"./tests/intern-local.ts",
+		"./tests/intern-saucelabs.ts",
 		"./tests/intern.ts",
 		"./tests/module.d.ts",
 		"./tests/support/Reporter.ts",


### PR DESCRIPTION
Updated Gruntfile and inter config files to allow both Saucelabs and BrowserStack to be used to run CI via different grunt tasks
