### PR TITLE
Fix how global define is unset

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -843,7 +843,6 @@
 	if (has('host-node')) {
 		loadNodeModule = (moduleId: string, parent?: DojoLoader.Module): any => {
 			let module: any = require('module');
-			let amdDefine = define;
 			let result: any;
 
 			if (module._findPath && module._nodeModulePaths) {
@@ -857,7 +856,7 @@
 			// Some modules attempt to detect an AMD loader by looking for global AMD `define`. This causes issues
 			// when other CommonJS modules attempt to load them via the standard Node.js `require`, so hide it
 			// during the load
-			define = undefined;
+			globalObject.define = undefined;
 
 			try {
 				result = requireModule.nodeRequire(moduleId);
@@ -869,7 +868,7 @@
 				result = undefined;
 			}
 			finally {
-				define = amdDefine;
+				globalObject.define = define;
 			}
 
 			return result;


### PR DESCRIPTION
`define` was just a local variable. Actually unset the global `define` when requiring a Node module.

Looks like there was no test for this behavior. I'd add it but not quite sure where to start.

---

This fixes `TypeError: ESP.parse is not a function` output in test runs, see [this Travis build](https://travis-ci.org/kitsonk/widgets/builds/116329358) for an example. In this case Intern uses loader to load a custom reporter, which then requires `istanbul/lib/instrumenter`. This module requires `esprima` which erroneously [selects the AMD loader](https://github.com/jquery/esprima/blob/eb05a03b18b8433ab1ebeabea635a949219cd75e/esprima.js#L32:L33).