### PR TITLE
#74: Add browser support table to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ This package provides a JavaScript AMD loader useful in applications running in 
 
 dojo-loader does not have any dependencies on a JavaScript framework.
 
+## Support
+
+| Environment	| Version	|
+|---------------|----------:|
+| IE			| 10+		|
+| Firefox		| current	|
+| Chrome		| current	|
+| Opera			| current	|
+| Edge			| current	|
+| Node			| 0.12+		|
+| Nashorn		| 1.8+		|
+
 ## Features
 
 - AMD loading

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ dojo-loader does not have any dependencies on a JavaScript framework.
 | Environment	| Version	|
 |---------------|----------:|
 | IE			| 10+		|
-| Firefox		| current	|
-| Chrome		| current	|
-| Opera			| current	|
-| Edge			| current	|
+| Firefox		| 30+		|
+| Chrome		| 30+		|
+| Opera			| 15+		|
+| Safari		| 8, 9		|
+| Android		| 4.4+		|
+| iOS			| 7+		|
 | Node			| 0.12+		|
 | Nashorn		| 1.8+		|
 


### PR DESCRIPTION
Fixes: https://github.com/dojo/loader/issues/74

Adds a support table

[ci skip]