### PR TITLE
Fix Loader Build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,9 +8,9 @@ module.exports = function (grunt) {
 		ts: {
 			tests: {
 				compilerOptions: {
-					module: 'umd'
+					module: 'umd',
+					outDir: '<%= devDirectory %>/tests'
 				},
-				outDir: '<%= devDirectory %>/tests',
 				include: [ 'tests/**/*.ts', 'typings/index.d.ts', 'src/interfaces.d.ts' ]
 			}
 		},

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,11 +7,11 @@ module.exports = function (grunt) {
 		/* loader has to build in a slightly different way than the standard Dojo 2 package */
 		ts: {
 			tests: {
-				options: {
+				compilerOptions: {
 					module: 'umd'
 				},
 				outDir: '<%= devDirectory %>/tests',
-				src: [ 'tests/**/*.ts', 'typings/index.d.ts', 'src/interfaces.d.ts' ]
+				include: [ 'tests/**/*.ts', 'typings/index.d.ts', 'src/interfaces.d.ts' ]
 			}
 		},
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,8 +44,7 @@ module.exports = function (grunt) {
 		'clean:dev',
 		'ts:dev',
 		'ts:tests',
-		'copy:staticTestFiles',
-		'updateTsconfig'
+		'copy:staticTestFiles'
 	]);
 
 	/* we also have to add the uglify task */

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,9 +22,9 @@ module.exports = function (grunt) {
 					banner: '/*! <%= name %>@<%= version %> - Copyright (c) 2016, The Dojo Foundation. ' +
 						'All rights reserved. */',
 					sourceMap: true,
-					sourceMapName: 'dist/umd/_debug/loader.min.js.map',
+					sourceMapName: 'dist/umd/loader.min.js.map',
 					sourceMapIncludeSources: true,
-					sourceMapIn: 'dist/umd/_debug/loader.js.map',
+					sourceMapIn: 'dist/umd/loader.js.map',
 					compress: {
 						dead_code: true,
 						unsafe: true

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
 		"istanbul": "0.4.3",
 		"remap-istanbul": "0.6.4",
 		"tslint": "next",
-		"typescript": "2.1.0-dev.20160819"
+		"typescript": "2.0.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	},
 	"main": "dist/umd/loader.js",
 	"scripts": {
-		"prepublish": "grunt dist dist_esm",
+		"prepublish": "grunt dist ts:esm",
 		"test": "grunt test"
 	},
 	"typings": "./dist/umd/dojo-loader.d.ts",

--- a/tests/functional/require/has.html
+++ b/tests/functional/require/has.html
@@ -13,7 +13,7 @@
 				packages: [
 					{
 						name: 'chai',
-						location: 'node_modules/intern/node_modules/chai',
+						location: 'node_modules/chai',
 						main: 'chai'
 					}
 				]

--- a/tests/functional/require/on/error.html
+++ b/tests/functional/require/on/error.html
@@ -13,7 +13,7 @@
 				packages: [
 					{
 						name: 'chai',
-						location: '../../../node_modules/intern/node_modules/chai',
+						location: '../../../node_modules/chai',
 						main: 'chai'
 					}
 				]

--- a/tests/functional/require/on/remove.html
+++ b/tests/functional/require/on/remove.html
@@ -13,7 +13,7 @@
 				packages: [
 					{
 						name: 'chai',
-						location: '../../../node_modules/intern/node_modules/chai',
+						location: '../../../node_modules/chai',
 						main: 'chai'
 					}
 				]

--- a/tests/functional/require/plugin-config.html
+++ b/tests/functional/require/plugin-config.html
@@ -13,7 +13,7 @@
 				packages: [
 					{
 						name: 'chai',
-						location: '../../node_modules/intern/node_modules/chai',
+						location: '../../node_modules/chai',
 						main: 'chai'
 					}
 				]

--- a/tests/functional/require/toAbsMid.html
+++ b/tests/functional/require/toAbsMid.html
@@ -13,7 +13,7 @@
 				packages: [
 					{
 						name: 'chai',
-						location: 'node_modules/intern/node_modules/chai',
+						location: 'node_modules/chai',
 						main: 'chai'
 					}
 				]

--- a/tests/functional/require/toUrl.html
+++ b/tests/functional/require/toUrl.html
@@ -13,7 +13,7 @@
 				packages: [
 					{
 						name: 'chai',
-						location: '../../../node_modules/intern/node_modules/chai',
+						location: '../../../node_modules/chai',
 						main: 'chai'
 					}
 				]

--- a/tests/functional/require/undef.html
+++ b/tests/functional/require/undef.html
@@ -13,7 +13,7 @@
 				packages: [
 					{
 						name: 'chai',
-						location: '../../node_modules/intern/node_modules/chai',
+						location: '../../node_modules/chai',
 						main: 'chai'
 					}
 				]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"version": "2.0.0",
 	"compilerOptions": {
 		"declaration": false,
-		"module": "commonjs",
+		"module": "umd",
 		"noImplicitAny": true,
 		"noImplicitThis": true,
 		"strictNullChecks": true,


### PR DESCRIPTION
We no longer move the source maps to a `_debug` directory, update `ts:tests` target configuration, fix failing functional tests.

Resolves https://github.com/dojo/loader/issues/84