### PR TITLE
Fix Loader Typings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,8 +2,22 @@
 
 module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-contrib-uglify');
+	grunt.loadNpmTasks('dts-generator');
 
 	require('grunt-dojo2').initConfig(grunt, {
+		dtsGenerator: {
+			options: {
+				baseDir: 'src',
+				name: '<%= name %>'
+			},
+			dist: {
+				options: {
+					out: 'dist/umd/<%= name %>.d.ts'
+				},
+				src: [ '<%= skipTests %>' ]
+			}
+		},
+
 		/* loader has to build in a slightly different way than the standard Dojo 2 package */
 		ts: {
 			tests: {
@@ -12,6 +26,11 @@ module.exports = function (grunt) {
 					outDir: '<%= devDirectory %>/tests'
 				},
 				include: [ 'tests/**/*.ts', 'typings/index.d.ts', 'src/interfaces.d.ts' ]
+			},
+			dist: {
+				compilerOptions: {
+					declaration: false
+				}
 			}
 		},
 
@@ -48,5 +67,5 @@ module.exports = function (grunt) {
 	]);
 
 	/* we also have to add the uglify task */
-	grunt.registerTask('dist', grunt.config.get('distTasks').concat('uglify:dist'));
+	grunt.registerTask('dist', grunt.config.get('distTasks').concat(['uglify:dist', 'dtsGenerator:dist']));
 };

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "type": "git",
     "url": "https://github.com/dojo/loader.git"
   },
-  "main": "dist/umd/loader.js",
+  "main": "loader.js",
+  "private": true,
   "scripts": {
-    "prepublish": "grunt dist ts:esm",
     "test": "grunt test"
   },
-  "typings": "./dist/umd/dojo-loader.d.ts",
+  "typings": "dojo-loader.d.ts",
   "devDependencies": {
     "codecov.io": "0.1.6",
     "dts-generator": "~1.7.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"version": "2.0.0",
 	"compilerOptions": {
 		"declaration": false,
-		"module": "umd",
+		"module": "commonjs",
 		"noImplicitAny": true,
 		"noImplicitThis": true,
 		"strictNullChecks": true,


### PR DESCRIPTION
- Configure `dts-generator` for dist pipeline as the loader needs to be referred globally.
- Override `declaration` for `dist` `ts` task as modules typings are not produced by `tsc`.
- Update paths for typings and main for flat packaging

