### PR TITLE
Adding AMD shim api, issue #69

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -46,6 +46,8 @@ declare namespace DojoLoader {
 
 		/* TODO: We should remove internal APIs like this */
 		pkgs?: { [ path: string ]: Package; };
+
+		shim?: { [path: string]: ModuleShim | string[] };
 	}
 
 	interface Define {
@@ -185,6 +187,12 @@ declare namespace DojoLoader {
 	}
 
 	interface PathMap extends MapReplacement {}
+
+	interface ModuleShim {
+		deps?: string[];
+		exports?: string;
+		init?: (...dependencies: any[]) => any;
+	}
 
 	interface Require {
 		(dependencies: string[], callback: RequireCallback): void;

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,4 +1,5 @@
 'use strict';
+import ModuleShim = DojoLoader.ModuleShim;
 
 declare const load: (module: string) => any;
 declare const Packages: {} | undefined;
@@ -28,7 +29,8 @@ declare const Packages: {} | undefined;
 		baseUrl: './',
 		packages: [],
 		paths: {},
-		pkgs: {}
+		pkgs: {},
+		shim: {}
 	};
 
 	// The arguments sent to loader via AMD define().
@@ -292,6 +294,48 @@ declare const Packages: {} | undefined;
 
 			// Note that old paths will get destroyed if reconfigured
 			configuration.paths && (pathMapPrograms = computeMapProgram(configuration.paths));
+
+			// shim API
+			if (config.shim !== undefined) {
+				Object.keys(config.shim).forEach((moduleId) => {
+					let moduleDef: ModuleShim = (config.shim || {})[ moduleId ];
+
+					// using shorthand module syntax, convert to full syntax
+					if ('length' in moduleDef) {
+						moduleDef = {
+							deps: <string[]> moduleDef
+						};
+					}
+
+					define(moduleId, moduleDef.deps || [], function (...dependencies) {
+						let root: any = undefined;
+
+						let globalPath = moduleDef.exports;
+
+						if (globalPath) {
+							root = globalObject;
+
+							globalPath.split('.').forEach((pathComponent) => {
+								if (!(pathComponent in root)) {
+									throw new Error(`Tried to find ${globalPath} but it did not exist`);
+								} else {
+									root = root[ pathComponent ];
+								}
+							});
+						}
+
+						if (moduleDef.init) {
+							let newReturnValue: any = moduleDef.init(...dependencies);
+
+							if (newReturnValue !== undefined) {
+								root = newReturnValue;
+							}
+						}
+
+						return root;
+					});
+				});
+			}
 		};
 	}
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -296,19 +296,19 @@ declare const Packages: {} | undefined;
 			configuration.paths && (pathMapPrograms = computeMapProgram(configuration.paths));
 
 			// shim API
-			if (config.shim !== undefined) {
+			if (config.shim) {
 				Object.keys(config.shim).forEach((moduleId) => {
 					let moduleDef: ModuleShim = (config.shim || {})[ moduleId ];
 
 					// using shorthand module syntax, convert to full syntax
-					if ('length' in moduleDef) {
+					if (Array.isArray(moduleDef)) {
 						moduleDef = {
 							deps: <string[]> moduleDef
 						};
 					}
 
 					define(moduleId, moduleDef.deps || [], function (...dependencies) {
-						let root: any = undefined;
+						let root: any;
 
 						let globalPath = moduleDef.exports;
 

--- a/tests/functional/all.ts
+++ b/tests/functional/all.ts
@@ -1,3 +1,4 @@
 import './basicAmdLoading';
 import './basicCommonJsLoading';
+import './shimAmdLoading';
 import './require/require';

--- a/tests/functional/shimAmdLoading.html
+++ b/tests/functional/shimAmdLoading.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+	<meta charset="UTF-8">
+	<title>Shim AMD Loading Test</title>
+</head>
+
+<body>
+<script src="../../src/loader.js"></script>
+<script>
+	var globalValues = {
+		string: 'string'
+	};
+
+	define('first-number', [], function() {
+		return 3;
+	});
+
+	define('second-number', [], function() {
+		return 5;
+	});
+
+	define('plugin-dep', [], function() {
+		window.pluginDep = 'plugin-dep';
+	});
+
+	require.config({
+		shim: {
+			'global/string': {
+				exports: 'globalValues.string'
+			},
+			'global/number': {
+				init: function() {
+					return 5;
+				}
+			},
+			'init-once': (function() {
+				var initCount = 0;
+
+				return {
+					init: function() {
+						return ++initCount;
+					}
+				};
+			})(),
+			'init-no-return': {
+				init: function() {
+				}
+			},
+			'adder': {
+				deps: ['first-number', 'second-number'],
+				init: function(firstNumber, secondNumber) {
+					return firstNumber + secondNumber;
+				}
+			},
+			'plugin': ['plugin-dep']
+		}
+	});
+
+	require([
+		'global/string',
+		'global/number',
+		'adder',
+		'init-no-return',
+		'init-once',
+		'init-once',
+		'plugin'
+	], function(stringValue, numberValue, addedValues, initNoReturn, initOnce, initTwice) {
+		window.loaderTestResults = {
+			stringValue: stringValue,
+			numberValue: numberValue,
+			addedValues: addedValues,
+			initNoReturn: initNoReturn,
+			initOnce: initOnce,
+			initTwice: initTwice,
+			pluginDep: window.pluginDep,
+			requireError: window.requireError
+		};
+	});
+</script>
+</body>
+</html>

--- a/tests/functional/shimAmdLoading.ts
+++ b/tests/functional/shimAmdLoading.ts
@@ -1,0 +1,24 @@
+import * as assert from 'intern/chai!assert';
+import * as registerSuite from 'intern!object';
+import executeTest from './executeTest';
+
+registerSuite({
+	name: 'Shim API AMD loading',
+
+	'shim tests'(this: any) {
+		return executeTest(this, './shimAmdLoading.html', function (results: any) {
+			assert.strictEqual(results.stringValue, 'string', 'Global value should have been read from nested path');
+			assert.strictEqual(results.numberValue, 5, 'Init return value should be used as module value');
+			assert.strictEqual(results.initTwice, 1, 'Module init function should only be called once');
+			assert.strictEqual(results.addedValues, 8, 'Module dependencies should have resolved');
+			assert.strictEqual(results.pluginDep, 'plugin-dep', 'Module dependencies should have loaded with no exports');
+			assert.isUndefined(results.initNotReturn, 'Empty module export and init function should result in empty object');
+		});
+	},
+
+	'non-existent global variable'(this: any) {
+		return executeTest(this, './shimAmdLoading2.html', function (results: any) {
+			assert.strictEqual(results.error, 'Tried to find badVariable but it did not exist', 'Non existent global variable expected to error');
+		});
+	}
+});

--- a/tests/functional/shimAmdLoading2.html
+++ b/tests/functional/shimAmdLoading2.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+	<meta charset="UTF-8">
+	<title>Shim AMD Loading Test</title>
+</head>
+
+<body>
+<script src="../../src/loader.js"></script>
+<script>
+	require.config({
+		shim: {
+			'error': {
+				exports: 'badVariable'
+			}
+		}
+	});
+
+	try {
+		require([
+			'error'
+		], function() {
+			window.loaderTestResults = {
+			};
+		});
+	} catch (e) {
+	    window.loaderTestResults = {
+	        error: e.message
+		}
+	}
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adding support for the AMD shim API, as [outlined here](https://github.com/amdjs/amdjs-api/blob/master/CommonConfig.md#shim-).

Example,

```html
<script src="jquery.js"></script>
<script src="loader.js"></script>
<script>
require.config({
    shim: {
        'jquery': {
            exports: '$'
        }
    }
});

define(['jquery'], function (tool) {
    // tool holds $
});
</script>
```