### PR TITLE
Adding readonly property to logically readonly variables, issue #82

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -68,8 +68,8 @@ declare namespace DojoLoader {
 	}
 
 	interface LoaderError extends Error {
-		src: string;
-		info: { module: Module, url: string, parentMid: string };
+		readonly src: string;
+		readonly info: { module: Module, url: string, parentMid: string };
 	}
 
 	/**


### PR DESCRIPTION
There weren't many places here that seemed like they would benefit from the `readonly` property, so I really only changed the error interface.  There are some other interfaces that are logically read only, but they are only used internally and not exposed, so I didn't really see much benefit in marking them (`MapItem`, `MapReplacement`, etc)