### PR TITLE
Adding data-loader-config attribute to loader script tag, issue 58

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -171,6 +171,7 @@ declare const Packages: {} | undefined;
 	has.add('debug', true);
 
 	has.add('loader-configurable', true);
+	has.add('loader-config-attribute', true);
 	if (has('loader-configurable')) {
 		/**
 		 * Configures the loader.
@@ -332,6 +333,27 @@ declare const Packages: {} | undefined;
 				});
 			}
 		};
+
+		if (has('loader-config-attribute') && has('host-browser')) {
+			Array.prototype.slice.call(document.getElementsByTagName('script'), 0).forEach((script: HTMLScriptElement) => {
+				if (script.hasAttribute('data-loader-config')) {
+					const attr = script.getAttribute('data-loader-config');
+					let dojoConfig: DojoLoader.Config | null = null;
+
+					try {
+						dojoConfig = <DojoLoader.Config> JSON.parse(`{ ${attr} }`);
+					}
+					catch (e) {
+						console.error('Unable to parse data-loader-config, ' + attr);
+						console.error(e);
+					}
+
+					if (dojoConfig !== null) {
+						requireModule.config(dojoConfig);
+					}
+				}
+			});
+		}
 	}
 
 	function forEach<T>(array: T[], callback: (value: T, index: number, array: T[]) => void): void {

--- a/tests/functional/all.ts
+++ b/tests/functional/all.ts
@@ -1,4 +1,5 @@
 import './basicAmdLoading';
 import './basicCommonJsLoading';
+import './scriptConfigReading';
 import './shimAmdLoading';
 import './require/require';

--- a/tests/functional/scriptConfigReading.html
+++ b/tests/functional/scriptConfigReading.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+	<head lang="en">
+		<meta charset="UTF-8">
+		<title>Script Config Reading Test</title>
+	</head>
+
+	<body>
+		<script data-loader-config='"packages": [{"name": "amdApp", "location": "./amdApp" }]' src="../../src/loader.js"></script>
+		<script>
+			require([
+				'amdApp/app'
+			], function (app) {
+				window.loaderTestResults = {
+					message: app.getMessage()
+				};
+			});
+		</script>
+	</body>
+</html>

--- a/tests/functional/scriptConfigReading.ts
+++ b/tests/functional/scriptConfigReading.ts
@@ -1,0 +1,15 @@
+import * as assert from 'intern/chai!assert';
+import * as registerSuite from 'intern!object';
+import executeTest from './executeTest';
+
+const AMD_APP_MESSAGE = 'Message from AMD app.';
+
+registerSuite({
+	name: 'Script tag configuration',
+
+	'script tag config'(this: any) {
+		return executeTest(this, './scriptConfigReading.html', function (results: any) {
+			assert.strictEqual(results.message, AMD_APP_MESSAGE);
+		});
+	}
+});


### PR DESCRIPTION
Adding a `data-loader-config` attribute for specifying loader configuration on the `script` tag.  Accepts JSON without the enclosing `{` `}` (similar to dojo 1)

```html
<script data-loader-config='"packages": [{"name": "package", "path": "package/path"}]' src"loader.js"></script>
```

This configuration is run on initialization of the loader, so it will happen _before_ any manual calls to `require.config`.