### PR TITLE
correct name of type file dts generator produces

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,11 +8,11 @@ module.exports = function (grunt) {
 		dtsGenerator: {
 			options: {
 				baseDir: 'src',
-				name: '<%= name %>'
+				name: 'dojo-loader'
 			},
 			dist: {
 				options: {
-					out: 'dist/umd/<%= name %>.d.ts'
+					out: 'dist/umd/dojo-loader.d.ts'
 				},
 				src: [ '<%= skipTests %>' ]
 			}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue

**Description:**

Update name of typings file.

Related to https://github.com/dojo/meta/issues/129