### PR TITLE
Adding a config property to control crossOrigin on script tags

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -49,7 +49,7 @@ declare namespace DojoLoader {
 
 		shim?: { [path: string]: ModuleShim | string[] };
 
-		crossOriginAttribute?: false | 'anonymous' | 'use-credentials';
+		crossOrigin?: false | 'anonymous' | 'use-credentials';
 	}
 
 	interface Define {

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -48,6 +48,8 @@ declare namespace DojoLoader {
 		pkgs?: { [ path: string ]: Package; };
 
 		shim?: { [path: string]: ModuleShim | string[] };
+
+		crossOriginAttribute?: false | 'anonymous' | 'use-credentials';
 	}
 
 	interface Define {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -31,7 +31,7 @@ declare const Packages: {} | undefined;
 		paths: {},
 		pkgs: {},
 		shim: {},
-		crossOriginAttribute: false
+		crossOrigin: false
 	};
 
 	// The arguments sent to loader via AMD define().
@@ -1024,8 +1024,8 @@ declare const Packages: {} | undefined;
 			node.addEventListener('load', handler, false);
 			node.addEventListener('error', handler, false);
 
-			if (config.crossOriginAttribute !== false) {
-				(<any> node).crossOrigin = config.crossOriginAttribute;
+			if (config.crossOrigin !== false) {
+				(<any> node).crossOrigin = config.crossOrigin;
 			}
 
 			node.charset = 'utf-8';

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -30,7 +30,8 @@ declare const Packages: {} | undefined;
 		packages: [],
 		paths: {},
 		pkgs: {},
-		shim: {}
+		shim: {},
+		crossOriginAttribute: false
 	};
 
 	// The arguments sent to loader via AMD define().
@@ -1023,7 +1024,10 @@ declare const Packages: {} | undefined;
 			node.addEventListener('load', handler, false);
 			node.addEventListener('error', handler, false);
 
-			(<any> node).crossOrigin = 'anonymous';
+			if (config.crossOriginAttribute !== false) {
+				(<any> node).crossOrigin = config.crossOriginAttribute;
+			}
+
 			node.charset = 'utf-8';
 			node.src = url;
 			document.head.appendChild(node);

--- a/tests/functional/all.ts
+++ b/tests/functional/all.ts
@@ -1,5 +1,6 @@
 import './basicAmdLoading';
 import './basicCommonJsLoading';
+import './crossOrigin';
 import './scriptConfigReading';
 import './shimAmdLoading';
 import './require/require';

--- a/tests/functional/amdApp/crossOrigin.js
+++ b/tests/functional/amdApp/crossOrigin.js
@@ -1,0 +1,14 @@
+(function() {
+	var scripts = document.getElementsByTagName('script'), i;
+
+	for (i = 0; i < scripts.length; i++) {
+		var script = scripts[i];
+
+		if (script.src && script.src.indexOf('crossOrigin.js') >= 0) {
+			window.crossOriginResult = {
+				node: script,
+				value: script.crossOrigin
+			};
+		}
+	}
+})();

--- a/tests/functional/amdApp/crossOrigin.js
+++ b/tests/functional/amdApp/crossOrigin.js
@@ -7,7 +7,7 @@
 		if (script.src && script.src.indexOf('crossOrigin.js') >= 0) {
 			window.crossOriginResult = {
 				node: script,
-				value: script.crossOrigin
+				value: script.crossOrigin || 'null'
 			};
 		}
 	}

--- a/tests/functional/crossOrigin.ts
+++ b/tests/functional/crossOrigin.ts
@@ -1,0 +1,23 @@
+import * as assert from 'intern/chai!assert';
+import * as registerSuite from 'intern!object';
+import executeTest from './executeTest';
+
+registerSuite({
+	name: 'Cross origin configuration',
+
+	'cross origin false'(this: any) {
+		return executeTest(this, './crossOriginFalse.html', function (results: any) {
+			assert.strictEqual(results.message, 'The cross origin value is null');
+		});
+	},
+	'cross origin anonymous'(this: any) {
+		return executeTest(this, './crossOriginAnon.html', function (results: any) {
+			assert.strictEqual(results.message, 'The cross origin value is anonymous');
+		});
+	},
+	'cross origin use-credentials'(this: any) {
+		return executeTest(this, './crossOriginCreds.html', function (results: any) {
+			assert.strictEqual(results.message, 'The cross origin value is use-credentials');
+		});
+	}
+});

--- a/tests/functional/crossOriginAnon.html
+++ b/tests/functional/crossOriginAnon.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+	<head lang="en">
+		<meta charset="UTF-8">
+		<title>Basic AMD Loading Test</title>
+	</head>
+
+	<body>
+		<script src="../../src/loader.js"></script>
+		<script>
+			require.config({
+                crossOriginAttribute: 'anonymous',
+				packages: [
+					{ name: 'amdApp', location: './amdApp' }
+				]
+			});
+			require([
+				'amdApp/crossOrigin'
+			], function (app) {
+				window.loaderTestResults = {
+					message: 'The cross origin value is ' + window.crossOriginResult.value
+				};
+			});
+		</script>
+	</body>
+</html>

--- a/tests/functional/crossOriginAnon.html
+++ b/tests/functional/crossOriginAnon.html
@@ -9,7 +9,7 @@
 		<script src="../../src/loader.js"></script>
 		<script>
 			require.config({
-                crossOriginAttribute: 'anonymous',
+                crossOrigin: 'anonymous',
 				packages: [
 					{ name: 'amdApp', location: './amdApp' }
 				]

--- a/tests/functional/crossOriginCreds.html
+++ b/tests/functional/crossOriginCreds.html
@@ -9,7 +9,7 @@
 		<script src="../../src/loader.js"></script>
 		<script>
 			require.config({
-                crossOriginAttribute: 'use-credentials',
+                crossOrigin: 'use-credentials',
 				packages: [
 					{ name: 'amdApp', location: './amdApp' }
 				]

--- a/tests/functional/crossOriginCreds.html
+++ b/tests/functional/crossOriginCreds.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+	<head lang="en">
+		<meta charset="UTF-8">
+		<title>Basic AMD Loading Test</title>
+	</head>
+
+	<body>
+		<script src="../../src/loader.js"></script>
+		<script>
+			require.config({
+                crossOriginAttribute: 'use-credentials',
+				packages: [
+					{ name: 'amdApp', location: './amdApp' }
+				]
+			});
+			require([
+				'amdApp/crossOrigin'
+			], function (app) {
+				window.loaderTestResults = {
+					message: 'The cross origin value is ' + window.crossOriginResult.value
+				};
+			});
+		</script>
+	</body>
+</html>

--- a/tests/functional/crossOriginCreds.html
+++ b/tests/functional/crossOriginCreds.html
@@ -9,7 +9,7 @@
 		<script src="../../src/loader.js"></script>
 		<script>
 			require.config({
-                crossOrigin: 'use-credentials',
+				crossOrigin: 'use-credentials',
 				packages: [
 					{ name: 'amdApp', location: './amdApp' }
 				]

--- a/tests/functional/crossOriginFalse.html
+++ b/tests/functional/crossOriginFalse.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+	<head lang="en">
+		<meta charset="UTF-8">
+		<title>Basic AMD Loading Test</title>
+	</head>
+
+	<body>
+		<script src="../../src/loader.js"></script>
+		<script>
+			require.config({
+                crossOriginAttribute: false,
+				packages: [
+					{ name: 'amdApp', location: './amdApp' }
+				]
+			});
+			require([
+				'amdApp/crossOrigin'
+			], function (app) {
+				window.loaderTestResults = {
+					message: 'The cross origin value is ' + window.crossOriginResult.value
+				};
+			});
+		</script>
+	</body>
+</html>

--- a/tests/functional/crossOriginFalse.html
+++ b/tests/functional/crossOriginFalse.html
@@ -9,7 +9,7 @@
 		<script src="../../src/loader.js"></script>
 		<script>
 			require.config({
-                crossOrigin: false,
+				crossOrigin: false,
 				packages: [
 					{ name: 'amdApp', location: './amdApp' }
 				]

--- a/tests/functional/crossOriginFalse.html
+++ b/tests/functional/crossOriginFalse.html
@@ -9,7 +9,7 @@
 		<script src="../../src/loader.js"></script>
 		<script>
 			require.config({
-                crossOriginAttribute: false,
+                crossOrigin: false,
 				packages: [
 					{ name: 'amdApp', location: './amdApp' }
 				]


### PR DESCRIPTION
Adding a `crossOrigin` attribute to the loader config for controlling the `crossorigin` property that gets added to `<script>` tags in the browser.

Possible values are,

* `false` - (default) Never add the attribute to the script tag
* `anonymous` - Add `crossorigin="anonymous"` to the script tag
* `use-credentials` - Add `crossorigin="use-credentials"` to the script tag