### PR TITLE
Fix require.undef() with cache injection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ env:
   global:
   - SAUCE_USERNAME: dojo2-ts-ci
   - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
-  - BROWSERSTACK_USERNAME: dtktestaccount1
-  - BROWSERSTACK_ACCESS_KEY: mG2qbEFJCZY2qLsM7yfx
+  - BROWSERSTACK_USERNAME: dylanschiemann2
+  - BROWSERSTACK_ACCESS_KEY: 2upt88qsxsqqeukQvecu
 before_install:
 - if [ ${TRAVIS_BRANCH-""} == "master" ] && [ -n ${encrypted_12c8071d2874_key-""}
   ]; then openssl aes-256-cbc -K $encrypted_12c8071d2874_key -iv $encrypted_12c8071d2874_iv

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -209,6 +209,7 @@ declare namespace DojoLoader {
 	}
 
 	interface RootRequire extends Require {
+		cache(cache: DojoLoader.ObjectMap): void;
 		has: Has;
 		on(type: SignalType, listener: any): { remove: () => void };
 		config(config: Config): void;
@@ -232,7 +233,7 @@ declare interface NodeRequire {
 	on(type: DojoLoader.SignalType, listener: any): { remove: () => void };
 	toAbsMid(moduleId: string): string;
 	toUrl(path: string): string;
-	undef(moduleId: string): void;
+	undef(moduleId: string, recursive?: boolean): void;
 }
 
 declare const arguments: IArguments;

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1108,7 +1108,8 @@ declare const Packages: {} | undefined;
 				if (recursive && module.deps) {
 					forEach(module.deps, undefDeps);
 				}
-				modules[id] = undefined;
+				delete modules[module.mid];
+				delete cache[module.mid];
 			}
 		};
 	}

--- a/tests/intern-local.ts
+++ b/tests/intern-local.ts
@@ -1,6 +1,6 @@
 export * from './intern';
 
-export const tunnel = 'NullTunnel';
+export const tunnel = 'SeleniumTunnel';
 export const tunnelOptions = {
 	hostname: 'localhost',
 	port: '4444'

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -22,9 +22,10 @@ export const environments = [
 	{ browserName: 'internet explorer', version: '11', platform: 'WINDOWS' },
 	{ browserName: 'edge', platform: 'WINDOWS' },
 	{ browserName: 'firefox', platform: 'WINDOWS' },
-	{ browserName: 'chrome', platform: 'WINDOWS' },
+	{ browserName: 'chrome', platform: 'WINDOWS' } /* ,
 	{ browserName: 'safari', version: '10', platform: 'MAC' },
-	{ browserName: 'iPad', version: '9.1' }
+	{ browserName: 'iPad', version: '9.1' } */
+	/* issues with Safari and iOS on BrowserStack with loader */
 ];
 
 // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -19,19 +19,19 @@ export const capabilities = {
 // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
 // capabilities options specified for an environment will be copied as-is
 export const environments = [
-	{ browserName: 'internet explorer', version: [ '10.0', '11.0' ], platform: 'Windows 7' },
-	{ browserName: 'microsoftedge', platform: 'Windows 10' },
-	{ browserName: 'firefox', platform: 'Windows 10' },
-	{ browserName: 'chrome', platform: 'Windows 10' },
-	{ browserName: 'safari', version: '9', platform: 'OS X 10.11' }
-	// { browserName: 'android', platform: 'Linux', version: '4.4', deviceName: 'Google Nexus 7 HD Emulator' }
+	{ browserName: 'internet explorer', version: '11', platform: 'WINDOWS' },
+	{ browserName: 'edge', platform: 'WINDOWS' },
+	{ browserName: 'firefox', platform: 'WINDOWS' },
+	{ browserName: 'chrome', platform: 'WINDOWS' },
+	{ browserName: 'safari', platform: 'MAC' },
+	{ browserName: 'iPad' }
 ];
 
 // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
-export const maxConcurrency = 4;
+export const maxConcurrency = 5;
 
 // Name of the tunnel class to use for WebDriver tests
-export const tunnel = 'SauceLabsTunnel';
+export const tunnel = 'BrowserStackTunnel';
 
 export const loaders = {
 	'host-browser': 'node_modules/@dojo/loader/loader.js',

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -23,8 +23,8 @@ export const environments = [
 	{ browserName: 'edge', platform: 'WINDOWS' },
 	{ browserName: 'firefox', platform: 'WINDOWS' },
 	{ browserName: 'chrome', platform: 'WINDOWS' },
-	{ browserName: 'safari', platform: 'MAC' },
-	{ browserName: 'iPad' }
+	{ browserName: 'safari', version: '10', platform: 'MAC' },
+	{ browserName: 'iPad', version: '9.1' }
 ];
 
 // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service

--- a/tests/unit/require.ts
+++ b/tests/unit/require.ts
@@ -661,6 +661,7 @@ registerSuite({
 			dfd.reject('Loading undefined module should throw an error');
 		});
 	},
+
 	'recurisve undef': {
 		'dependencies are unloaded'(this: any) {
 			let dfd = this.async(DEFAULT_TIMEOUT);
@@ -706,6 +707,39 @@ registerSuite({
 		'modules without dependencies work as expected'() {
 			global.require.undef('invalid-module', true);
 		}
+	},
+
+	'cache injected module is properly undefined'(this: any) {
+		let dfd = this.async(DEFAULT_TIMEOUT);
+
+		global.require.config({
+			packages: [
+				{
+					name: 'common',
+					location: './_build/tests/common'
+				}
+			]
+		});
+
+		global.require.cache({
+			'common/app'() {
+				define([], () => {
+					return 'mock';
+				});
+			}
+		});
+
+		global.require.cache({}); /* TODO: Remove when #124 resolve */
+
+		global.require([
+			'common/app'
+		], dfd.callback(function (app: any) {
+			assert.strictEqual(app, 'mock', 'should return cache factory value');
+			global.require.undef('common/app');
+			assert.throws(() => {
+				global.require('common/app');
+			}, Error, 'Attempt to require unloaded module');
+		}));
 	},
 
 	plugin: {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR ensures that if a modules has been injected via `require.cache()` that when it is `require.undef()` that it removes the cached factory as well.

Resolves #125 
Resolves #126
