### PR TITLE
Adding to cache as soon as require.cache is called instead of pending…

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -98,14 +98,6 @@ declare const Packages: {} | undefined;
 	// a "program" to apply paths; see computeMapProg
 	let pathMapPrograms: DojoLoader.PathMap[] = [];
 
-	// hash: (mid | url)-->(function | string)
-	//
-	// Gives a set of cache modules pending entry into cache. When cached modules are published to the loader, they are
-	// entered into pendingCacheInsert; modules are then pressed into cache upon (1) AMD define or (2) upon receiving
-	// another independent set of cached modules. (1) is the usual case, and this case allows normalizing mids given
-	// in the pending cache for the local configuration, possibly relocating modules.
-	let pendingCacheInsert: { [moduleId: string]: any; } = {};
-
 	let setGlobals: (require: DojoLoader.RootRequire, define: DojoLoader.Define) => void;
 
 	let uidGenerator = 0;
@@ -850,7 +842,7 @@ declare const Packages: {} | undefined;
 
 			++waitingCount;
 			module.injected = true;
-			if ((cached = cache[module.mid]) || (module.mid in pendingCacheInsert)) {
+			if (cached = cache[module.mid]) {
 				try {
 					cached();
 					onLoadCallback();
@@ -1112,7 +1104,7 @@ declare const Packages: {} | undefined;
 				item = cacheModules[key];
 
 				cache[
-					typeof item === 'string' ? toUrl(key, undefined) : getModuleInformation(key, undefined).mid
+					getModuleInformation(key, undefined).mid
 					] = item;
 			}
 		}

--- a/tests/unit/require.ts
+++ b/tests/unit/require.ts
@@ -741,7 +741,26 @@ registerSuite({
 		});
 	},
 
-	'cache injected module is properly undefined'(this: any) {
+	'circular dependencies are required'(this: any) {
+		let dfd = this.async(DEFAULT_TIMEOUT);
+
+		global.require.config({
+			packages: [
+				{
+					name: 'recursive',
+					location: './_build/tests/common/recursive'
+				}
+			]
+		});
+
+		global.require([
+			'recursive/a'
+		], dfd.callback(function (a: any) {
+			assert.equal(a, 'a');
+		}));
+	},
+
+	'require.cache creates modules with only the cache call'(this: any) {
 		let dfd = this.async(DEFAULT_TIMEOUT);
 
 		global.require.config({
@@ -761,7 +780,34 @@ registerSuite({
 			}
 		});
 
-		global.require.cache({}); /* TODO: Remove when #124 resolve */
+		assert.doesNotThrow(() => {
+			global.require([
+				'common/app'
+			], dfd.callback((app: any) => {
+				assert.strictEqual(app, 'mock', 'should return cache factory value');
+			}));
+		});
+	},
+
+	'cache injected module is properly undefined'(this: any) {
+		let dfd = this.async(DEFAULT_TIMEOUT);
+
+		global.require.config({
+			packages: [
+				{
+					name: 'common',
+					location: './_build/tests/common'
+				}
+			]
+		});
+
+		global.require.cache({
+			'common/app'() {
+				define([], () => {
+					return 'mock';
+				});
+			}
+		});
 
 		global.require([
 			'common/app'


### PR DESCRIPTION
… it for later, issue #124

**Type:** bug 

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

It looks like maybe there was some logic to defer a `require.cache` operation until it was required for the first time, so it could get a reference module, but what's being done now doesn't really line up with that. It's now adding to the cache as soon as you call `require.cache`.

Resolves #124 
