### PR TITLE
Undefining a module no longer undefines special modules, issue #128

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1099,9 +1099,13 @@ declare const Packages: {} | undefined;
 		requireModule.undef = function (id: string, recursive?: boolean): void {
 			const module: Module | undefined = modules[id];
 			const undefDeps = function (mod: Module): void {
+				if (mod === commonJsRequireModule || mod === commonJsModuleModule || mod === commonJsExportsModule) {
+					return;
+				}
 				if (mod.deps) {
 					forEach(mod.deps, undefDeps);
 				}
+
 				modules[mod.mid] = undefined;
 			};
 			if (module) {

--- a/tests/unit/require.ts
+++ b/tests/unit/require.ts
@@ -709,6 +709,38 @@ registerSuite({
 		}
 	},
 
+	'important modules are not undefined'(this: any) {
+		let dfd = this.async(DEFAULT_TIMEOUT);
+
+		global.define('undef-module', ['require', 'module', 'exports'], (require: any, module: any, exports: any) => {
+			return {
+				require,
+				module,
+				exports
+			};
+		});
+
+		global.require(['undef-module'], function () {
+			global.require.undef('undef-module', true);
+
+			global.define('undef-module-2', ['require', 'module', 'exports'], (require: any, module: any, exports: any) => {
+				return {
+					require,
+					module,
+					exports
+				};
+			});
+
+			assert.doesNotThrow(() => {
+				global.require(['undef-module-2'], dfd.callback((defs: any) => {
+					assert.isTrue(defs.require !== undefined);
+					assert.isTrue(defs.module !== undefined);
+					assert.isTrue(defs.exports !== undefined);
+				}));
+			});
+		});
+	},
+
 	'cache injected module is properly undefined'(this: any) {
 		let dfd = this.async(DEFAULT_TIMEOUT);
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fix for undefining modules that have dependencies on `require`, `exports`, or `module`. These special modules should never be undefined!

Resolves #128
