### PR TITLE
Upgrade to TypeScript 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "grunt-contrib-uglify": "^2.0.0",
     "grunt-dojo2": "latest",
     "intern": "~3.4.1",
-    "typescript": "~2.3.2"
+    "typescript": "~2.4.1"
   }
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR updates the loader to use TypeScript 2.4.

Refs dojo/meta#189
