### PR TITLE
Adding support for npm namespaces

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,6 +1,7 @@
 'use strict';
 import ModuleShim = DojoLoader.ModuleShim;
 import Module = DojoLoader.Module;
+import Package = DojoLoader.Package;
 
 declare const load: (module: string) => any;
 declare const Packages: {} | undefined;
@@ -544,16 +545,16 @@ declare const Packages: {} | undefined;
 	}
 
 	function getModuleInformation(moduleId: string, referenceModule?: DojoLoader.Module): DojoLoader.Module {
-		let match = moduleId.match(/^((?:@[^\/]*\/)?[^\/]+)(\/(.+))?$/);
-		let packageId = match ? match[1] : '';
-		let pack = config && config.pkgs ? config.pkgs[packageId] : {};
+		let packageId = '';
+		let pack: Package = {};
 		let moduleIdInPackage = '';
 
-		if (pack) {
-			moduleId = packageId + '/' + (moduleIdInPackage = ((match && match[3]) || pack.main || 'main'));
-		}
-		else {
-			packageId = '';
+		const matches = Object.keys((config && config.pkgs || {})).filter(pkg => moduleId.indexOf(pkg) === 0).sort((a, b) => a.length > b.length ? -1 : 1);
+
+		if (matches.length) {
+			packageId = matches.shift() as string;
+			pack = config.pkgs![packageId];
+			moduleId = packageId + '/' + (moduleIdInPackage = (moduleId.substr(packageId.length + 1) || pack.main || 'main'));
 		}
 
 		let module = modules[moduleId];

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -544,7 +544,7 @@ declare const Packages: {} | undefined;
 	}
 
 	function getModuleInformation(moduleId: string, referenceModule?: DojoLoader.Module): DojoLoader.Module {
-		let match = moduleId.match(/^([^\/]+)(\/(.+))?$/);
+		let match = moduleId.match(/^((?:@[^\/]*\/)?[^\/]+)(\/(.+))?$/);
 		let packageId = match ? match[1] : '';
 		let pack = config && config.pkgs ? config.pkgs[packageId] : {};
 		let moduleIdInPackage = '';

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -549,7 +549,7 @@ declare const Packages: {} | undefined;
 		let pack: Package = {};
 		let moduleIdInPackage = '';
 
-		const matches = Object.keys((config && config.pkgs || {})).filter(pkg => moduleId.indexOf(pkg) === 0).sort((a, b) => a.length > b.length ? -1 : 1);
+		const matches = Object.keys((config && config.pkgs || {})).filter(pkg => (moduleId + '/').indexOf(pkg + '/') === 0).sort((a, b) => a.length > b.length ? -1 : 1);
 
 		if (matches.length) {
 			packageId = matches.shift() as string;

--- a/tests/functional/require/config/packages3.html
+++ b/tests/functional/require/config/packages3.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+	<meta charset="UTF-8">
+	<title>require.config Test</title>
+</head>
+
+<body>
+<script src="../../../../src/loader.js"></script>
+<script>
+	require.config({
+		packages: [
+			{
+				name: '@test/common',
+				location: '../../../common'
+			}
+		]
+	});
+
+	require([
+		'@test/common/app'
+	], function (app) {
+		window.loaderTestResults = app;
+	});
+</script>
+</body>
+</html>

--- a/tests/functional/require/config/packages4.html
+++ b/tests/functional/require/config/packages4.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+	<meta charset="UTF-8">
+	<title>require.config Test</title>
+</head>
+
+<body>
+<script src="../../../../src/loader.js"></script>
+<script>
+	require.config({
+		packages: [
+			{ name: '@common', location: '../../../common' },
+			{ name: '@common/a', location: '../../../common/a', main: 'app' }
+		]
+	});
+
+	require([
+		'@common/app',
+		'@common/a'
+	], function (app) {
+		window.loaderTestResults = app;
+	});
+</script>
+</body>
+</html>

--- a/tests/functional/require/require.ts
+++ b/tests/functional/require/require.ts
@@ -103,6 +103,12 @@ registerSuite({
 				return executeTest(this, './config/packages3.html', function (results: any) {
 					assert.strictEqual(results, appMessage, '"app" module should load');
 				});
+			},
+
+			'nested packages'(this: any) {
+				return executeTest(this, './config/packages4.html', function (results: any) {
+					assert.strictEqual(results, appMessage, '"app" module should load');
+				});
 			}
 		},
 

--- a/tests/functional/require/require.ts
+++ b/tests/functional/require/require.ts
@@ -97,6 +97,12 @@ registerSuite({
 				return executeTest(this, './config/packages2.html', function (results: any) {
 					assert.strictEqual(results, appMessage, '"app" module should load');
 				});
+			},
+
+			'package name with slashes'(this: any) {
+				return executeTest(this, './config/packages3.html', function (results: any) {
+					assert.strictEqual(results, appMessage, '"app" module should load');
+				});
 			}
 		},
 

--- a/tests/unit/require.ts
+++ b/tests/unit/require.ts
@@ -505,6 +505,27 @@ registerSuite({
 				], dfd.callback(function (app: any) {
 					assert.strictEqual(app, 'app', '"app" module should load');
 				}));
+			},
+			'slashes in package name'(this: any) {
+				let dfd = this.async(DEFAULT_TIMEOUT);
+
+				setErrorHandler(dfd);
+
+				global.require.config({
+					packages: [
+						{
+							name: '@test/common',
+							location: './_build/tests/common',
+							main: 'app'
+						}
+					]
+				});
+
+				global.require([
+					'@test/common'
+				], dfd.callback(function (app: any) {
+					assert.strictEqual(app, 'app', '"app" module should load');
+				}));
 			}
 		},
 

--- a/tests/unit/require.ts
+++ b/tests/unit/require.ts
@@ -526,6 +526,27 @@ registerSuite({
 				], dfd.callback(function (app: any) {
 					assert.strictEqual(app, 'app', '"app" module should load');
 				}));
+			},
+			'single @ package'(this: any) {
+				let dfd = this.async(DEFAULT_TIMEOUT);
+
+				setErrorHandler(dfd);
+
+				global.require.config({
+					packages: [
+						{
+							name: '@test',
+							location: './_build/tests',
+							main: 'app'
+						}
+					]
+				});
+
+				global.require([
+					'@test/common/app'
+				], dfd.callback(function (app: any) {
+					assert.strictEqual(app, 'app', '"app" module should load');
+				}));
 			}
 		},
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding support for npm namespaces when loading modules. Previously, a configuration like this,

```typescript
require.config({
    packages: [
        {
            name: '@some-package/some-module',
            location: '/path/to/some-package/some-module'
        }
    ]
});
```

`@some-package/some-module` would get interpreted as `@some-package/some-module.js` because `package/main` syntax is supported. This would cause the package configuration to not apply as the name would not be what you expected.

With this change, if a module id contains the `@` sign, it is considered part of the package name.

Resolves #143 
