### PR TITLE
Remove dependency on chai and use what comes with Intern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,29 @@
 {
   "name": "@dojo/loader",
-  "version": "0.1.1",
+  "version": "0.1.2-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@dojo/core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@dojo/core/-/core-0.1.0.tgz",
-      "integrity": "sha512-boiwQHfV7idOZfZnDzgLrofS2LA7ELGKjd6tl0/hLBunJ3psozAd4CpNcT7XC00/OPYFIxVHFEpI+FZNlpUgfw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@dojo/core/-/core-0.3.0.tgz",
+      "integrity": "sha512-SnmiQcbPUqtjzy1sOmkLvg3C6UFUaXDNUNqHzGaF2QM1Ebp1Lw+j+BE+E6uJgxISlgckjAZ6myjwFI+obZ316w==",
       "dev": true
     },
     "@dojo/has": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@dojo/has/-/has-0.1.0.tgz",
-      "integrity": "sha512-orYLbYVTcqNpZBmPNRlidUyCn/WuV4jV4JvTAy4Je/zQq9m9Nb8gK+8X7/iOUjSJbP1+vv1ld9Q3932IGC1IyA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@dojo/has/-/has-0.1.1.tgz",
+      "integrity": "sha512-McwwBLpM0R0zsIy0+1WkHFXYYNalMOPJydqW3dd089K+AaOCto4AtFKA6+GDEuXDgJE9cMG5tX48hFwIL3dtxQ==",
       "dev": true
     },
     "@dojo/interfaces": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.1.0.tgz",
-      "integrity": "sha512-rpBALDc5Ya/+JrlyFvrt7wKGdGA1xq2gSFGce6j3L9meB8tAFYQvs/bx9DDp+CSdpEzzeVZWr8C4FpoUId2New==",
-      "dev": true
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.0.tgz",
+      "integrity": "sha512-sgqHsKraTjKDoLfWece/E/ip29CsV3z+vEDSIzuBSWtXDEau6/pDRhbhuSnxjBB1bvvB8Drn93xWkO+PqqQ0Dg==",
+      "dev": true,
+      "requires": {
+        "@types/yargs": "8.0.2"
+      }
     },
     "@dojo/loader": {
       "version": "0.1.0",
@@ -29,45 +32,50 @@
       "dev": true
     },
     "@dojo/shim": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.1.0.tgz",
-      "integrity": "sha512-008RP8DB175ib26dde7wQWFiYIbSACFaArLdLHYdY/cQLN9s3yVj2Gtp5C/9YoY3Ziy9wA241myOjy6QcVHcWw==",
-      "dev": true
-    },
-    "@theintern/digdug": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.0.1.tgz",
-      "integrity": "sha512-MCF9jwQWAbBhy6NTQiaLeOrPOOtijYX9/LfyDyJJqnq6c0icBL4XfV58eudIXNiZtTYFiVwFh104dlCgL7+Auw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.3.tgz",
+      "integrity": "sha512-DzpD1D90D1vsHuqPqGb78JFfykf0Nvbel+iAupYVPEwq+LVxAZPDC8nGZRsAaVfWSsFLuKPcbRRIInf+emCFAw==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.1.0",
-        "@dojo/has": "0.1.0",
-        "@dojo/interfaces": "0.1.0",
-        "@dojo/shim": "0.1.0",
+        "intersection-observer": "0.4.3",
+        "pepjs": "0.4.3",
+        "tslib": "1.8.0"
+      }
+    },
+    "@theintern/digdug": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.0.4.tgz",
+      "integrity": "sha512-BTcYNMxOnGlTEaOYqab9WygE2sLz9ZRWRsuTwUttceewzEDn/Ok/4lWdIgwwX+bb3MybvFPU1wBkq8Co+Bfqyw==",
+      "dev": true,
+      "requires": {
+        "@dojo/core": "0.3.0",
+        "@dojo/has": "0.1.1",
+        "@dojo/interfaces": "0.2.0",
+        "@dojo/shim": "0.2.3",
         "decompress": "4.2.0",
         "semver": "5.4.1",
         "tslib": "1.8.0"
       }
     },
     "@theintern/leadfoot": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.0.1.tgz",
-      "integrity": "sha512-6aWQP7Qf5pvh8iEvDS+5gCbazqmb40PXADsGLBOZmKorC3WLELpP4Dw0GkeWKf4UYJ/4xKPwUX4gNTbYlF74kA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.0.3.tgz",
+      "integrity": "sha512-J9wLAMjAU+Wyv5jGmHdVN4xnuyaD24kK7mAoLUPBLRNxflkJoTo9Ph5g4BKUHp+xpKd/IMU00ulgMMf++Xqm4A==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.1.0",
-        "@dojo/has": "0.1.0",
-        "@dojo/interfaces": "0.1.0",
-        "@dojo/shim": "0.1.0",
+        "@dojo/core": "0.3.0",
+        "@dojo/has": "0.1.1",
+        "@dojo/interfaces": "0.2.0",
+        "@dojo/shim": "0.2.3",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
         "tslib": "1.8.0"
       }
     },
     "@types/babel-types": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.1.tgz",
-      "integrity": "sha512-7Z6r20+HE0viAFhsW0d/UrC1K2tTlpXzGpNlYm8MmCv8z5PbAacFIshrM/MjlGRa5SBqxu2socpy8FHntwZKng==",
+      "version": "6.25.2",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
+      "integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA==",
       "dev": true
     },
     "@types/benchmark": {
@@ -83,13 +91,13 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "6.0.91"
+        "@types/node": "6.0.92"
       }
     },
     "@types/chai": {
-      "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.4.35.tgz",
-      "integrity": "sha1-6NZfg0ktKUT4FvxiB0GCHCioyQA=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
+      "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
       "dev": true
     },
     "@types/charm": {
@@ -98,7 +106,7 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.91"
+        "@types/node": "6.0.92"
       }
     },
     "@types/diff": {
@@ -114,17 +122,17 @@
       "dev": true,
       "requires": {
         "@types/body-parser": "1.16.8",
-        "@types/express-serve-static-core": "4.0.56",
+        "@types/express-serve-static-core": "4.0.57",
         "@types/serve-static": "1.13.1"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.0.56",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.56.tgz",
-      "integrity": "sha512-/0nwIzF1Bd4KGwW4lhDZYi5StmCZG1DIXXMfQ/zjORzlm4+F1eRA4c6yJQrt4hqX//TDtPULpSlYwmSNyCMeMg==",
+      "version": "4.0.57",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.57.tgz",
+      "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.91"
+        "@types/node": "6.0.92"
       }
     },
     "@types/fs-extra": {
@@ -133,7 +141,7 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.91"
+        "@types/node": "6.0.92"
       }
     },
     "@types/glob": {
@@ -143,7 +151,7 @@
       "dev": true,
       "requires": {
         "@types/minimatch": "3.0.1",
-        "@types/node": "6.0.91"
+        "@types/node": "6.0.92"
       }
     },
     "@types/grunt": {
@@ -152,7 +160,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.91"
+        "@types/node": "6.0.92"
       }
     },
     "@types/handlebars": {
@@ -162,9 +170,9 @@
       "dev": true
     },
     "@types/highlight.js": {
-      "version": "9.12.1",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.1.tgz",
-      "integrity": "sha512-rjk9iOMh8dwRzzaqP6t4uCNZOiKOfdyhC1tXxX8sX8DC9qgTKnqm1oGTmuy0zKz0SFZ3RzlmEO3VUwh+qUIgLQ==",
+      "version": "9.12.2",
+      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.2.tgz",
+      "integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==",
       "dev": true
     },
     "@types/http-errors": {
@@ -191,7 +199,7 @@
       "integrity": "sha512-BWj7zRtwVU5KzuYL/zNuVoSvYWIpT02smNMpQwQbJjwEyITEGSKsxVIT4b2bzXCWFMq76ss0sdY/5yw3NwTlIA==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "6.25.1",
+        "@types/babel-types": "6.25.2",
         "@types/istanbul-lib-coverage": "1.1.0",
         "@types/source-map": "0.1.29"
       }
@@ -232,9 +240,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.85",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.85.tgz",
-      "integrity": "sha512-HrZiwDl62if0z31+rB99CLlg7WzS7b+KmyW75XAHEl/ZG0De2ACo6skZ89Zh3jOWkjKObN0Apq3MUezg7u9NKQ==",
+      "version": "4.14.87",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
+      "integrity": "sha512-AqRC+aEF4N0LuNHtcjKtvF9OTfqZI0iaBoe3dA6m/W+/YZJBZjBmW/QIZ8fBeXC6cnytSY9tBoFBqZ9uSCeVsw==",
       "dev": true
     },
     "@types/marked": {
@@ -262,9 +270,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.91",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.91.tgz",
-      "integrity": "sha512-0Ev07CZ/Hrc/4qIX3DCNVaaTS9JLn1k2k/omXIkOsJD2q1/JGtwV72slKPZuPBTjq8X7RstutlsIBqkSwP9AKQ==",
+      "version": "6.0.92",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
+      "integrity": "sha512-awEYSSTn7dauwVCYSx2CJaPTu0Z1Ht2oR1b2AD3CYao6ZRb+opb6EL43fzmD7eMFgMHzTBWSUzlWSD+S8xN0Nw==",
       "dev": true
     },
     "@types/platform": {
@@ -279,7 +287,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.91"
+        "@types/node": "6.0.92"
       }
     },
     "@types/serve-static": {
@@ -288,7 +296,7 @@
       "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.0.56",
+        "@types/express-serve-static-core": "4.0.57",
         "@types/mime": "2.0.0"
       }
     },
@@ -304,7 +312,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.91"
+        "@types/node": "6.0.92"
       }
     },
     "@types/source-map": {
@@ -325,8 +333,14 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.91"
+        "@types/node": "6.0.92"
       }
+    },
+    "@types/yargs": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz",
+      "integrity": "sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
@@ -565,7 +579,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000764",
+        "caniuse-db": "1.0.30000778",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -771,9 +785,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
     "bl": {
@@ -859,9 +873,9 @@
       }
     },
     "boxen": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz",
-      "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
         "ansi-align": "2.0.0",
@@ -870,7 +884,7 @@
         "cli-boxes": "1.0.0",
         "string-width": "2.1.1",
         "term-size": "1.2.0",
-        "widest-line": "1.0.0"
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -952,8 +966,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000764",
-        "electron-to-chromium": "1.3.27"
+        "caniuse-db": "1.0.30000778",
+        "electron-to-chromium": "1.3.28"
       }
     },
     "buffer": {
@@ -1008,15 +1022,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000764",
+        "caniuse-db": "1.0.30000778",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000764",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000764.tgz",
-      "integrity": "sha1-1zqxGuYvap4vaYZ9bZwjrj8uXY0=",
+      "version": "1.0.30000778",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000778.tgz",
+      "integrity": "sha1-Fnxg6VQqKqYFN8RG+ziB2FOjByo=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1808,9 +1822,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
-      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
+      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
       "dev": true
     },
     "emojis-list": {
@@ -2291,7 +2305,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.7.0"
+        "nan": "2.8.0"
       }
     },
     "function-bind": {
@@ -2427,12 +2441,12 @@
       }
     },
     "global-dirs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.0.tgz",
-      "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "1.3.4"
+        "ini": "1.3.5"
       }
     },
     "globals": {
@@ -2631,9 +2645,9 @@
       }
     },
     "grunt-dojo2": {
-      "version": "2.0.0-beta2.14",
-      "resolved": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-2.0.0-beta2.14.tgz",
-      "integrity": "sha512-0wtYueLW3+89TVZYHQJrs7l1wM0DoeEmk1lDEOLfJ6DlvVfmCw+kyw87InUs0EedkO/7nCmJE2NWtk4fpXyZ4w==",
+      "version": "2.0.0-beta2.15",
+      "resolved": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-2.0.0-beta2.15.tgz",
+      "integrity": "sha512-inDpdjlZrb6F5VTIlMDDCPxN1wtM27axEW9feHrmzh/x1CyelfzsvfkbbmqkP/XHlVrGNmHkO8BuTSDqCDn+BA==",
       "dev": true,
       "requires": {
         "codecov.io": "0.1.6",
@@ -2649,7 +2663,10 @@
         "grunt-ts": "5.5.1",
         "grunt-tslint": "4.0.1",
         "grunt-typings": "0.1.5",
-        "intern": "4.1.1",
+        "intern": "4.1.3",
+        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-report": "1.1.2",
+        "istanbul-reports": "1.1.3",
         "lodash": "4.17.4",
         "parse-git-config": "0.4.3",
         "pkg-dir": "1.0.0",
@@ -3136,25 +3153,25 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "intern": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.1.tgz",
-      "integrity": "sha512-Ljx3bz8zcPLOtfbDLxR/Nt3P8SCkTSikmZHg+iAUn1TqoBi56swxH6Vi9KEzhjWqFuFbFbmvW+3afiVYrq2vRA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.3.tgz",
+      "integrity": "sha512-IWaqzIwc+KQcoyiG+INvvv9L0fPKmgDSj+LySSWgnPc0VnYT1vgEmmxpwSlMPHDtfMMqq28/5/tsQVRx4EM2bQ==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.1.0",
-        "@dojo/has": "0.1.0",
-        "@dojo/interfaces": "0.1.0",
-        "@dojo/shim": "0.1.0",
-        "@theintern/digdug": "2.0.1",
-        "@theintern/leadfoot": "2.0.1",
+        "@dojo/core": "0.3.0",
+        "@dojo/has": "0.1.1",
+        "@dojo/interfaces": "0.2.0",
+        "@dojo/shim": "0.2.3",
+        "@theintern/digdug": "2.0.4",
+        "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
-        "@types/chai": "4.0.4",
+        "@types/chai": "4.0.8",
         "@types/charm": "1.0.1",
         "@types/diff": "3.2.2",
         "@types/express": "4.0.39",
@@ -3165,7 +3182,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.0",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.85",
+        "@types/lodash": "4.14.87",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -3199,12 +3216,6 @@
         "ws": "2.3.1"
       },
       "dependencies": {
-        "@types/chai": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.4.tgz",
-          "integrity": "sha512-cvU0HomQ7/aGDQJZsbtJXqBQ7w4J4TqLB0Z/h8mKrpRjfeZEvTbygkfJEb7fWdmwpIeDeFmIVwAEqS0OYuUv3Q==",
-          "dev": true
-        },
         "body-parser": {
           "version": "1.17.2",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
@@ -3332,9 +3343,15 @@
       }
     },
     "interpret": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
+    "intersection-observer": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.4.3.tgz",
+      "integrity": "sha512-sRobbVo/+DVGkbco/UkuREmXSr5ypWeQ7S7tYDhzIIP3NFtAHLkkFYdivFAIgNe4sfDYBFAjxEgUyxiEmA/dgQ==",
       "dev": true
     },
     "invariant": {
@@ -3386,7 +3403,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -3458,8 +3475,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "0.1.0",
-        "is-path-inside": "1.0.0"
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
       }
     },
     "is-natural-number": {
@@ -3490,9 +3507,9 @@
       "dev": true
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
@@ -3780,9 +3797,9 @@
       }
     },
     "js-base64": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
-      "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
+      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
       "dev": true
     },
     "js-tokens": {
@@ -4209,9 +4226,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
+      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
       "dev": true
     },
     "math-expression-evaluator": {
@@ -4382,9 +4399,9 @@
       }
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
       "dev": true,
       "optional": true
     },
@@ -4707,7 +4724,7 @@
         "extend-shallow": "2.0.1",
         "fs-exists-sync": "0.1.0",
         "git-config-path": "1.0.1",
-        "ini": "1.3.4"
+        "ini": "1.3.5"
       }
     },
     "parse-glob": {
@@ -4814,6 +4831,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
+    "pepjs": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/pepjs/-/pepjs-0.4.3.tgz",
+      "integrity": "sha1-FggOlwqud5kTdWwtrviOqnSG30E=",
       "dev": true
     },
     "pify": {
@@ -4965,7 +4988,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.3.2",
+        "js-base64": "2.4.0",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
@@ -6158,7 +6181,7 @@
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
       },
@@ -6690,7 +6713,7 @@
       "dev": true,
       "requires": {
         "glob": "7.0.0",
-        "interpret": "1.0.4",
+        "interpret": "1.1.0",
         "rechoir": "0.6.2"
       }
     },
@@ -7363,7 +7386,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "nan": "2.7.0",
+            "nan": "2.8.0",
             "node-pre-gyp": "0.6.39"
           },
           "dependencies": {
@@ -8413,8 +8436,8 @@
       "requires": {
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
-        "@types/highlight.js": "9.12.1",
-        "@types/lodash": "4.14.85",
+        "@types/highlight.js": "9.12.2",
+        "@types/lodash": "4.14.87",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",
@@ -8422,7 +8445,7 @@
         "handlebars": "4.0.5",
         "highlight.js": "9.12.0",
         "lodash": "4.17.4",
-        "marked": "0.3.6",
+        "marked": "0.3.7",
         "minimatch": "3.0.4",
         "progress": "1.1.8",
         "shelljs": "0.7.8",
@@ -8478,9 +8501,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
-      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
       "dev": true
     },
     "typings-core": {
@@ -8518,7 +8541,7 @@
         "thenify": "3.3.0",
         "throat": "3.2.0",
         "touch": "1.0.0",
-        "typescript": "2.6.1",
+        "typescript": "2.6.2",
         "xtend": "4.0.1",
         "zip-object": "0.1.0"
       },
@@ -8567,9 +8590,9 @@
       "optional": true
     },
     "ultron": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
     },
     "umd-wrapper": {
@@ -8664,7 +8687,7 @@
       "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
       "dev": true,
       "requires": {
-        "boxen": "1.2.2",
+        "boxen": "1.3.0",
         "chalk": "2.3.0",
         "configstore": "3.1.1",
         "import-lazy": "2.1.0",
@@ -8871,34 +8894,12 @@
       "dev": true
     },
     "widest-line": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        }
+        "string-width": "2.1.1"
       }
     },
     "window-size": {
@@ -8969,7 +8970,7 @@
       "dev": true,
       "requires": {
         "safe-buffer": "5.0.1",
-        "ultron": "1.1.0"
+        "ultron": "1.1.1"
       },
       "dependencies": {
         "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "typings": "dojo-loader.d.ts",
   "devDependencies": {
     "@dojo/loader": "beta3",
-    "@types/chai": "~3.4.0",
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
     "@types/node": "~6.0.0",


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Intern now uses the new typings for chai which conflict with the pinned ones.