### PR TITLE
Don't leak global definitions where possible

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -236,4 +236,4 @@ declare interface NodeRequire {
 	undef(moduleId: string, recursive?: boolean): void;
 }
 
-declare const arguments: IArguments;
+declare var arguments: IArguments;

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -3,9 +3,8 @@ import ModuleShim = DojoLoader.ModuleShim;
 import Module = DojoLoader.Module;
 import Package = DojoLoader.Package;
 
-declare const load: (module: string) => any;
-declare const Packages: {} | undefined;
-declare const importScripts: ((url: string) => void);
+// Nashorn global
+declare var Packages: { [key: string]: any; } | undefined;
 
 (function (args?: string[]): void {
 	let globalObject: any = (function (): any {
@@ -23,6 +22,12 @@ declare const importScripts: ((url: string) => void);
 		}
 		return {};
 	})();
+
+	// Nashorn global
+	const load: (module: string) => any = globalObject.load;
+
+	// webworker global
+	const importScripts: ((url: string) => void) = globalObject.importScripts;
 
 	const EXECUTING = 'executing';
 	const ABORT_EXECUTION: Object = {};


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

Don't leak global definitions where possible and declare them as var so they are not thought to be block scoped by TypeScript.

Resolves #154
